### PR TITLE
Feature: `schema.prisma`にデータモデルを定義する (#28)

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -8,6 +8,94 @@ generator client {
 }
 
 datasource db {
-  provider = "postgresql"
-  url      = env("DATABASE_URL")
+  provider  = "postgresql"
+  url       = env("DATABASE_URL")
+}
+
+// Organizationテーブル
+model Organization {
+  id          String   @id @default(uuid())
+  name        String
+  departments Department[]
+
+  @@map("organizations")
+}
+
+// ユーザー権限を定義
+enum Role {
+  ADMIN
+  EMPLOYEE
+}
+
+// Userモデル（認証基盤）
+model User {
+  id              String  @id @default(uuid())
+  email           String  @unique
+  password        String
+  role            Role
+  adminProfile    Admin?
+  employeeProfile Employee?
+
+  @@map("users")
+}
+
+// Adminsテーブル
+model Admin {
+  id                String       @id @default(uuid())
+  userId            String       @unique
+  user              User         @relation(fields: [userId], references: [id], onDelete: Cascade) 
+  departmentId      String
+  department        Department   @relation(fields: [departmentId], references: [id])
+  employees         Employee[]   @relation("AdminToEmployee")
+  name              String
+
+  @@index([departmentId])
+  @@map("admins")
+}
+
+//Departmentsテーブル
+model Department {
+  id              String        @id @default(uuid())
+  organizationId  String
+  organization    Organization  @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+  name            String
+  admins          Admin[]
+  employees       Employee[]
+
+  @@index([organizationId])
+  @@map("departments")
+}
+
+// Employeesテーブル
+model Employee {
+  id               String      @id @default(uuid())
+  userId           String      @unique
+  user             User        @relation(fields: [userId], references: [id], onDelete: Cascade)
+  departmentId     String
+  department       Department  @relation(fields: [departmentId], references: [id])
+  admins           Admin[]     @relation("AdminToEmployee")
+  name             String
+  health           HealthRecord[]
+
+  @@index([departmentId])
+  @@map("employees")
+}
+
+enum HealthCondition {
+  GOOD
+  CAUTION
+  BAD
+}
+
+// HealthRecordsテーブル
+model HealthRecord {
+  id                String      @id @default(uuid())
+  employeeId        String
+  employee          Employee    @relation(fields: [employeeId], references: [id], onDelete: Cascade)
+  condition         HealthCondition
+  comment           String
+  recordedDate      DateTime    @default(now())
+
+  @@index([employeeId])
+  @@map("health_records")
 }


### PR DESCRIPTION
* feature: Depertmentsテーブルまで作成

* Feature: Healthテーブルまで作成

* fix: タイポとリレーションを修正

* fix: タイポ修正

* fix: Prismaの命名規則に合わせてモデル名とフィールド名を修正

* fix: タイポ修正

* fix: Healthモデルのタイポ修正

* fix: Healthテーブルのマッピング等修正

* fix: healthモデルのマッピング名を修正

* fix: 不要なリレーションを削除

* fix: リレーション整理

* fix: Healthモデルの名称変更

* fix: パフォーマンスを最適化するため、外部キーにindexを追加

* fix: 認証情報集約のため、Userモデルを作成

* fix: 重複していたフィールドを削除

* fix: インデックス定義ミス修正

* fix: 外部キー制約エラー回避のため、子レコードにCascadeオプションを設定

* fix: conditionの型修正

* fix: 型安全性を確保するため、体調のenumを定義