### PR TITLE
fix: Prisma用のポート設定を追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,9 @@
 .env.*
 *.env
 
+#ローカル環境
+docker-compose.override.yml
+
 # ログ・テスト・キャッシュ
 **/coverage/
 *.log

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,6 @@ services:
       - /backend/node_modules
     ports:
       - "3000:3000" #NestJSのデフォルト
-      - "5555:5555" #Prismaのデフォルト
     environment:
       - DATABASE_URL=postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@db:5432/${POSTGRES_DB}?schema=public
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,6 +22,7 @@ services:
       - /backend/node_modules
     ports:
       - "3000:3000" #NestJSのデフォルト
+      - "5555:5555" #Prismaのデフォルト
     environment:
       - DATABASE_URL=postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@db:5432/${POSTGRES_DB}?schema=public
     depends_on:


### PR DESCRIPTION
### やったこと
`Ptisma Studio`のGUIへアクセスできるようにするため、
`docker-compose.yml`のportsににPrisma用のport5555番を追加した

### 対応イシュー
#34 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * ローカル開発向けのファイルを Git 追跡対象から除外するよう設定を更新しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->