### PR TITLE
fix: Prisma用のポート設定を追加 (#35)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,9 @@
 .env.*
 *.env
 
+#ローカル環境
+docker-compose.override.yml
+
 # ログ・テスト・キャッシュ
 **/coverage/
 *.log


### PR DESCRIPTION
* fix: Prisma用のポート設定を追加

* fix: prismaのポート設定を開発環境のみに制限

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **保守**
  * ローカル開発環境の Docker Compose 設定ファイルをバージョン管理から除外しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->