### PR TITLE
Fix: Dockerコンテナとホストとのボリュームマウントをできるようにする

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,6 @@
 # backend
 /backend/dist/
 /backend/build/
-/backend/src/generated/
 
 # frontend
 /frontend/.next/

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -5,7 +5,6 @@
 
 generator client {
   provider = "prisma-client-js"
-  output   = "../src/generated/client"
 }
 
 datasource db {

--- a/backend/src/prisma/prisma.service.ts
+++ b/backend/src/prisma/prisma.service.ts
@@ -1,5 +1,5 @@
 import { Injectable, OnModuleDestroy, OnModuleInit } from '@nestjs/common';
-import { PrismaClient } from '../generated/client';
+import { PrismaClient } from '@prisma/client';
 
 @Injectable()
 export class PrismaService extends PrismaClient implements OnModuleInit, OnModuleDestroy {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,12 +20,14 @@ services:
     volumes:
       - ./backend:/backend
       - /backend/node_modules
+      - /backend/node_modules/.prisma #コンテナ内のPrisma出力ファイルを保護
     ports:
       - "3000:3000" #NestJSのデフォルト
     environment:
       - DATABASE_URL=postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@db:5432/${POSTGRES_DB}?schema=public
     depends_on:
       - db
+    command: sh -c "npx prisma generate && npm run start" #コンテナ起動時にも自動でprisma generateを走らせる
   
   frontend:
     container_name: frontend


### PR DESCRIPTION
### 状況
- `npx prisma generate`を実行しても型定義ファイルのインポートエラーが消えない
- Prismaの自動生成コードが存在せず、backendコンテナを起動してもすぐ落ちてしまう
- 上記によりbackendコンテナに入ってコマンドをたたく操作ができず、作業が止まってしまう
- 一時的にローカル上に自動生成コードを置いて参照する設定にしたが、生成されたprisma/clientを.gitignoreで変更履歴から外しているため
機能実装をするたびにインポートエラーが再発してしまう

### 修正目的
-インポートエラーが再再発しないようにする

### アプローチ
- Prisma Clientの出力先をnode_modules(デフォルト)に戻す
- Prisma Clientをマウントの設定を変更してボリュームから保護する

### 作業ブランチ
fix/issue55

### 対応イシュー
#55 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * データベースクライアント生成プロセスを最適化しました。
  * Docker環境での初期化時に自動生成処理が実行されるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->