### PR TITLE
Fix: ビルド時間削減のため、重複していたCOPYとRUNコマンドを削除

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -8,9 +8,6 @@ RUN npm install
 COPY . .
 RUN npx prisma generate
 
-COPY prisma ./prisma
-RUN npx prisma generate
-
 EXPOSE 3000
 
 CMD [ "npm", "run", "start" ]


### PR DESCRIPTION
### やったこと
backendのDockerfileで、以下コマンドを削除した

- `COPY prisma ./prisma`
- `RUN npx prisma generate`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * ビルド手順を整理し、関連ファイルの取り込み方法を統一しました。
  * これにより、ビルド時の生成処理がより安定して実行されるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->